### PR TITLE
Run chrome in docker

### DIFF
--- a/browsers/Vagrantfile
+++ b/browsers/Vagrantfile
@@ -17,26 +17,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # forward vnc
-  config.vm.network :forwarded_port, guest: 5900, host: 5900 
+  config.vm.network :forwarded_port, guest: 5901, host: 5901
   # forward selenium
-  config.vm.network :forwarded_port, guest: 4444, host: 4444 
-  #forward chrome remote debugger
-  config.vm.network :forwarded_port, guest: 9222, host: 9222 
-
-  # ansible
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "ansible/test.yml"
-    ansible.sudo = true
-  end
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network :private_network, ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network :public_network
+  config.vm.network :forwarded_port, guest: 4444, host: 4444
+  # forward chrome remote debugger
+  config.vm.network :forwarded_port, guest: 9222, host: 9222
 
   # If true, then any SSH connections made will enable agent forwarding.
   # Default value: false
@@ -46,7 +31,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder ".", "/app/consistency"
   config.vm.synced_folder "", "/docker"
 
   # Provider-specific configuration so you can fine-tune various
@@ -54,10 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Example for VirtualBox:
   #
   config.vm.provider :virtualbox do |vb|
-  #   # Don't boot with headless mode
-  #   vb.gui = true
-  #
-  #   # Use VBoxManage to customize the VM. For example to change memory:
+  # Use VBoxManage to customize the VM. For example to change memory:
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
 

--- a/browsers/ansible/site.yml
+++ b/browsers/ansible/site.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: local
+- hosts: all
   sudo: yes
   roles:
     - common
     - nodejs
+    - chrome
     - firefox


### PR DESCRIPTION
[Delivers #84297818]

We can now run chrome when testing Fathom inside our docker image!
- The Vagrant file changes aren't necessary, because, well, we don't use it...
  but they were helpful when debugging.
